### PR TITLE
refactor: modernize build scripts for Quartz v5

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "obsidian_quartz"]
 	path = obsidian_quartz
 	url = https://github.com/cupid5trick/obsidian_quartz.git
-	branch = v4
+	branch = v5

--- a/build.sh
+++ b/build.sh
@@ -3,17 +3,20 @@
 set -exu
 
 Usage() {
-  # To debug this build script:
-  """
-  for workflow testing:
-  export GITHUB_TOKEN=xxxxxx
-  sudo act -j trigger-hook   --env GITHUB_TOKEN=$GITHUB_TOKEN   --bind $(pwd)/98-publish:$(pwd)/98-publish   --pull=false
+  cat <<'EOF'
+Usages:
+  $0 posts_dir site_dir archive_name site_repo   # production build (Netlify)
+  $0 local-dev                                   # local dev: prepare only, then hugo serve
 
-  local development:
+Environments:
+  GITHUB_TOKEN         Netlify secret; fetches the DocumentSync release archive
+  QUARTZ_ACL_PASSWORD  Optional; only needed if the archive contains @acl/private
+                       notes (see obsidian_quartz/docs/advanced/protected-notes.md).
+
+Local development:
   ./build.sh local-dev && hugo serve --config config-loveit.yaml -e production -DEF --minify --bind 0.0.0.0 --port 1313
-  """
-  echo "Usages: $0 posts_dir, site_dir, archive_name, site_repo"
-  echo "Environments: GITHUB_TOKEN"
+  # to also serve the Quartz site: cd obsidian_quartz && ./dev_setup.sh <vault>
+EOF
   exit 1
 }
 
@@ -89,15 +92,30 @@ build_site() {
   hugo --config config-loveit.yaml -e production --minify -DEF --gc
 }
 
-# build obsidian site
+# build obsidian site (Quartz v5 static build)
 build_obsidian() {
-  chmod +x *.sh
-  ./dev_setup.sh $(realpath $posts_dir)
-  npx quartz build -o ../public/obsidian --baseDir ../public/obsidian
+  # obsidian_quartz is a submodule pinned to a v5 commit (see .gitmodules / PR #1).
+  local site_abs_dir
+  site_abs_dir="$(realpath "$site_dir")"
+  cd "$site_abs_dir/obsidian_quartz"
+
+  # Source build-time secrets (QUARTZ_ACL_PASSWORD) from a gitignored acl.env if present
+  if [ -f "./acl.env" ]; then
+    set -a
+    . ./acl.env
+    set +a
+  fi
+
+  # v5: `-d` selects the content dir, `-o` the output. Do NOT use dev_setup.sh here —
+  # it ends in `npx quartz build --serve`, which would block a production build.
+  # The base URL is taken from quartz.config.yaml, not a build flag.
+  npm install
+  npx quartz plugin install
+  npx quartz build -d "$(realpath "$posts_dir")" -o "$site_abs_dir/public/obsidian"
 }
 
 rm -rf public obsidian_quartz/public
 
 fetch
 build_site
-cd obsidian_quartz && build_obsidian
+build_obsidian

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,9 @@
 
   [build.environment]
     HUGO_VERSION = "0.122.0"
+    # Quartz v5 requires Node >= 22.18 (runtime TS type-stripping). Must match
+    # obsidian_quartz/.node-version (v22.20.0).
+    NODE_VERSION = "22.20.0"
 
 [context.production.environment]
   HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
## Summary
Modernize the wrapper build pipeline for Quartz v5 while keeping the Hugo (LoveIt) site.

- **`build.sh`**: `build_obsidian()` no longer calls `dev_setup.sh` (which in v5 ends in `npx quartz build --serve` and would hang a Netlify production build) and drops the serve-only `--baseDir`. It now runs a v5 static build: `npm install` → `npx quartz plugin install` → `npx quartz build -d <content> -o public/obsidian`. Also sources a gitignored `acl.env` for `QUARTZ_ACL_PASSWORD`.
- **`netlify.toml`**: `NODE_VERSION = "22.20.0"` (Quartz v5 needs ≥ 22.18 for runtime TS type-stripping; matches the submodule `.node-version`).
- **`.gitmodules`**: track the `v5` branch.
- **`obsidian_quartz` submodule pointer**: bumped to commit `9d9b095` — the head of [cupid5trick/obsidian_quartz#1](https://github.com/cupid5trick/obsidian_quartz/pull/1) (ACL-encryption feature + HTTPS dev setup). Merge that PR first so the pointer resolves.

## Why
The previous `build_obsidian()` was written for Quartz v4 (`--baseDir` at build time, `dev_setup.sh` serve flow) and would block CI under v5.

## Current state
- `bash -n build.sh` clean; the v5 build command path is the same one used by the dev server and verified locally.
- `QUARTZ_ACL_PASSWORD` only required if the fetched archive contains `@acl/private` notes (the public `archive-public.tgz` already strips them); otherwise set it in Netlify site settings as a build-time secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)